### PR TITLE
Fix interactions between cost reductions and in-battle upgrades

### DIFF
--- a/src/LBoL-Entity-Sideloader/GameFixes/FixCostChangeOnUpgrade.cs
+++ b/src/LBoL-Entity-Sideloader/GameFixes/FixCostChangeOnUpgrade.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using HarmonyLib;
+using LBoL.Base;
+using LBoL.Core.Cards;
+
+namespace LBoLEntitySideloader.GameFixes
+{
+
+    // patch to fix interaction between base/temporary cost reduction and in-battle upgrades
+    [HarmonyPatch]
+    static class Cost
+    {
+        [HarmonyPatch(typeof(Card), nameof(Card.CostChangeInUpgrading)), HarmonyPrefix]
+        private static bool FixCostChange(Card __instance)
+        {
+            if (__instance.IsXCost || null == __instance.Config.UpgradedCost)
+            {
+                return false;
+            }
+
+            ManaGroup configDecrease =
+                __instance.Config.Cost - __instance.Config.UpgradedCost.Value;
+
+            if (ManaGroup.Empty == configDecrease)
+            {
+                return false;
+            }
+
+            // final correction
+            ManaGroup baseCorrection = __instance.Config.Cost != __instance.BaseCost
+                    ? (__instance.BaseCost - configDecrease).GetCostCorrection()
+                    : ManaGroup.Empty;
+            ManaGroup turnCorrection = ManaGroup.Empty != __instance.TurnCostDelta
+                    ? (__instance.BaseCost - configDecrease - baseCorrection + __instance.TurnCostDelta).GetCostCorrection()
+                    : ManaGroup.Empty;
+
+            __instance.DecreaseBaseCost(configDecrease + baseCorrection);
+            __instance.DecreaseTurnCost(turnCorrection);
+            return false;
+        }
+    }
+
+
+
+
+    public static class ManaGroupExtensions
+    {
+        public static ManaGroup GetCostCorrection(this ManaGroup delta)
+        {
+            ManaGroup surplus = (delta * (-1)).Corrected;
+            ManaGroup deficit = delta.Corrected;
+
+            ManaGroup result = ManaGroup.Empty;
+
+            // redistribute surplus to hybrid/any mana in deficit
+            if (0 < deficit.Hybrid)
+            {
+                foreach (ManaColor c in deficit.GetHybridColors)
+                {
+                    int pips = Math.Min(surplus[c], deficit.Hybrid);
+
+                    surplus -= ManaGroup.FromColor(c, pips);
+                    result -= ManaGroup.FromColor(c, pips);
+
+                    deficit -= ManaGroup.FromColor(ManaColor.Hybrid, pips);
+                    result += ManaGroup.FromColor(ManaColor.Hybrid, pips);
+                }
+            }
+
+            foreach (ManaColor c in surplus.EnumerateColors())
+            {
+                int pips = Math.Min(deficit[ManaColor.Any], surplus[c]);
+
+                surplus -= ManaGroup.FromColor(c, pips);
+                result -= ManaGroup.FromColor(c, pips);
+
+                deficit -= ManaGroup.Anys(pips);
+                result += ManaGroup.Anys(pips);
+            }
+
+            return result;
+        }
+    }
+
+
+
+
+}

--- a/src/LBoL-Entity-Sideloader/PluginInfo.cs
+++ b/src/LBoL-Entity-Sideloader/PluginInfo.cs
@@ -9,7 +9,7 @@ namespace LBoLEntitySideloader
     {
         public const string GUID = "neo.lbol.frameworks.entitySideloader";
         public const string description = "Entity Sideloader";
-        public const string version = "0.9.7841";
+        public const string version = "0.9.7842";
 
         public static readonly Harmony harmony = new Harmony(GUID);
     }

--- a/src/LBoL-Entity-Sideloader/README.md
+++ b/src/LBoL-Entity-Sideloader/README.md
@@ -6,6 +6,8 @@ Modding framework for working with LBoL entities.
 [cyaneko](https://github.com/cyaneko)
 
 #### Change log
+`0.9.7842` Fix some interactions between cost reductions and in-battle upgrades. Mostly affects 1XX -> 2X style upgrades.
+
 `0.9.7840` Hard deprecate `LBoLEntitySideloader.ExtraFunc.AutoCastAction`.
 
 `0.9.7830` Small fix for 1.7.2.


### PR DESCRIPTION
Changes how cost reduction redistribution happens (base and temporary) when a card is upgraded in battle.
Bugfix mainly for case of 1XX -> 2X upgrades and temp cost reduction to 0, which in vanilla causes the cost post-upgrade to be X instead of 0. No other cards are negatively affected or change behaviour to my knowledge, but verification is appreciated.

Some of my raw notes on how this works:
```
==================================================
If a pip disappeared from the cost:
1. redistribute the surplus to any remaining valid hybrid cost
2. redistribute all other surplus to generic cost
3. base cost affects base cost decrease first (Master of Collection), tempcost second via proxy since temp cost decrease indirectly depends on base cost when it is applied
4. temp cost affects temp cost only
5. in case of a tie, WUBRGC mana order decides what pips are redistributed
==================================================

==================================================
cost surplus and deficit after upgrade for baseCost and tempCost:
baseCost - configDec -> negative component is baseCost surplus, positive is deficit
baseCost - baseCorr - configDec + tempCostDelta -> negative component is tempCost surplus, positive is deficit
==================================================

==================================================
assumption: base cost reductions are via Master of Collection
==================================================

==================================================
example: base cost 1UUBB, upgrade 2UB(U/B)
1. base cost reduced to 1UB, then temp reduced to 0
base delta -UB, temp delta -1UB
base delta surplus 0, deficit 2(U/B), -UB -> -UB
temp delta surplus UB, deficit 2(U/B), -1UB -> -1(U/B)B; U takes priority due to mana order
2. base cost reduced to 1UU, then temp reduced to 0
base delta -BB, temp delta -1UU
base delta surplus B, deficit 2(U/B), -BB -> -(U/B)B
temp delta surplus U, deficit 2, temp delta -1UU -> -2U
==================================================

==================================================
example: base cost 1UUBB, upgrade 1(U/B)(U/B)(U/B)(U/B)
base cost reduced to 1UB, then temp reduced to 0
base delta -UB, temp delta -1UB
base delta surplus UB, deficit 1(U/B)(U/B)(U/B)(U/B), -UB -> -(U/B)(U/B)
temp delta surplus UB, deficit (U/B)(U/B), -1UB -> -1(U/B)(U/B)
==================================================

==================================================
example: base cost 1UUBB, upgrade 1UU(U/B)(U/B)
base cost reduced to 1BB, then temp reduced to 0
base delta -UU, temp delta -1BB
base delta surplus 0, deficit 1(U/B)(U/B), -UU -> -UU
temp delta surplus BB, deficit (U/B)(U/B), -1BB -> -1(U/B)(U/B)
==================================================

==================================================
example: base cost 1UUBB, upgrade 1UB(U/B)(U/B)
base cost reduced to 1UB, then temp reduced to 0
base delta -UB, temp delta -1UB
base delta surplus 0, deficit 1(U/B)(U/B), -UB -> -UB
temp delta surplus UB, deficit (U/B)(U/B), -1UB -> -1(U/B)(U/B)
==================================================

==================================================
example: base cost 1UUBB, upgrade 1BB
base cost reduced to 1UB, no temp delta reduction
base delta -UB
base delta surplus U, deficit 1B, -UB -> -1B
==================================================

==================================================
example: base cost 1BB, upgrade 2B
base cost reduced to BB, then temp reduced to 1
base delta -1, temp delta +1-BB
base delta surplus 0, deficit 1B, -1 -> -1
temp delta surplus B, deficit 1, +1-BB -> -B
==================================================

==================================================
example: base cost UUBB, upgrade 1UB(U/B)
base cost reduced to UBB, then temp reduced to 1
base delta -U, temp delta +1-UBB
base delta surplus 0, deficit 1B(U/B), -U -> -U
temp delta surplus UB, deficit 1(U/B), +1-UBB -> -B(U/B); U priority
==================================================
```